### PR TITLE
New flag parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: go
+
+go:
+  - 1.4
+  - tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,1 @@
 language: go
-
-go:
-  - 1.4
-  - tip

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-config
 
-[ ![Codeship Status for jimmysawczuk/go-config](https://codeship.com/projects/47df1c70-96ff-0132-8354-7a1406c9da98/status?branch=master)](https://codeship.com/projects/63102)
+[ ![travis-ci status for jimmysawczuk/go-config](https://travis-ci.org/jimmysawczuk/go-config.svg)](https://travis-ci.org/jimmysawczuk/go-config)
 
 **go-config** is a configuration library for Go that can process configuration from the source code itself, config files, and the command line.
 

--- a/config.go
+++ b/config.go
@@ -8,7 +8,6 @@ import (
 )
 
 var baseOptionSet OptionSet
-var configFlags *flag.FlagSet
 
 func init() {
 	resetBaseOptionSet(true)
@@ -16,9 +15,6 @@ func init() {
 
 func resetBaseOptionSet(add_defaults bool) {
 	baseOptionSet = make(OptionSet)
-
-	configFlags = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-	configFlags.Usage = func() {}
 
 	if add_defaults {
 		Add(String("config", "config.json", "The filename of the config file to use", false))
@@ -39,7 +35,7 @@ func String(name string, default_value string, description string, exportable bo
 		Type:         reflect.TypeOf(default_value),
 
 		Exportable: exportable,
-		flag:       configFlags.String(name, default_value, description),
+		// flag:       configFlags.String(name, default_value, description),
 	}
 
 	return &opt
@@ -57,7 +53,7 @@ func Bool(name string, default_value bool, description string, exportable bool) 
 		Type:         reflect.TypeOf(default_value),
 
 		Exportable: exportable,
-		flag:       configFlags.Bool(name, default_value, description),
+		// flag:       configFlags.Bool(name, default_value, description),
 	}
 
 	return &opt
@@ -75,7 +71,7 @@ func Int(name string, default_value int64, description string, exportable bool) 
 		Type:         reflect.TypeOf(default_value),
 
 		Exportable: exportable,
-		flag:       configFlags.Int64(name, default_value, description),
+		// flag:       configFlags.Int64(name, default_value, description),
 	}
 
 	return &opt
@@ -93,7 +89,7 @@ func Float(name string, default_value float64, description string, exportable bo
 		Type:         reflect.TypeOf(default_value),
 
 		Exportable: exportable,
-		flag:       configFlags.Float64(name, default_value, description),
+		// flag:       configFlags.Float64(name, default_value, description),
 	}
 
 	return &opt
@@ -109,13 +105,11 @@ func Add(o *Option) {
 // set in the "config" option.
 func Build() error {
 	// parse flags
-	parse_err := configFlags.Parse(os.Args[1:])
-	if parse_err != flag.ErrHelp && parse_err != nil {
+	fs := NewFlagSet(os.Args[0], os.Args[1:])
+	parse_err := fs.Parse()
+	if parse_err != nil {
 		os.Exit(2)
 	}
-
-	// set default values
-	importFlags(true)
 
 	// determine location of config file, import it
 	file := FileIO{Filename: Require("config").String()}
@@ -128,18 +122,17 @@ func Build() error {
 		}
 	}
 
-	// overwrite with flag
-	importFlags(false)
+	fs = NewFlagSet(os.Args[0], os.Args[1:])
+	parse_err = fs.Parse()
+	if parse_err != nil {
+		os.Exit(2)
+	}
 
-	if parse_err == flag.ErrHelp {
+	if fs.ShowHelp() {
 		Usage()
 		os.Exit(0)
 		return nil
 	}
-
-	// throw back args to the flag package
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	flag.CommandLine.Parse(configFlags.Args())
 
 	// export new config to file if necessary
 	if Require("config-export").Bool() || Require("config-generate").Bool() {
@@ -149,6 +142,9 @@ func Build() error {
 	if Require("config-generate").Bool() {
 		os.Exit(0)
 	}
+
+	os.Args = fs.Release()
+	flag.Parse()
 
 	return nil
 }
@@ -177,29 +173,29 @@ func Get(key string) (*Option, error) {
 	return s, nil
 }
 
-func importFlags(visitall bool) {
-	setter := func(f *flag.Flag) {
-		if v, exists := baseOptionSet.Get(f.Name); exists {
-			var val interface{}
+// func importFlags(visitall bool) {
+// 	setter := func(f *flag.Flag) {
+// 		if v, exists := baseOptionSet.Get(f.Name); exists {
+// 			var val interface{}
 
-			switch v.flag.(type) {
-			case *string:
-				val = *(v.flag.(*string))
-			case *int64:
-				val = *(v.flag.(*int64))
-			case *float64:
-				val = *(v.flag.(*float64))
-			case *bool:
-				val = *(v.flag.(*bool))
-			}
+// 			switch v.flag.(type) {
+// 			case *string:
+// 				val = *(v.flag.(*string))
+// 			case *int64:
+// 				val = *(v.flag.(*int64))
+// 			case *float64:
+// 				val = *(v.flag.(*float64))
+// 			case *bool:
+// 				val = *(v.flag.(*bool))
+// 			}
 
-			v.Value = val
-		}
-	}
+// 			v.Value = val
+// 		}
+// 	}
 
-	if visitall {
-		configFlags.VisitAll(setter)
-	} else {
-		configFlags.Visit(setter)
-	}
-}
+// 	if visitall {
+// 		configFlags.VisitAll(setter)
+// 	} else {
+// 		configFlags.Visit(setter)
+// 	}
+// }

--- a/config.go
+++ b/config.go
@@ -106,7 +106,7 @@ func Add(o *Option) {
 func Build() error {
 	// parse flags
 	fs := NewFlagSet(os.Args[0], os.Args[1:])
-	parse_err := fs.Parse()
+	parse_err := fs.ParseBuiltIn()
 	if parse_err != nil {
 		os.Exit(2)
 	}
@@ -128,7 +128,7 @@ func Build() error {
 		os.Exit(2)
 	}
 
-	if fs.ShowHelp() {
+	if fs.HasHelpFlag() {
 		Usage()
 		os.Exit(0)
 		return nil
@@ -172,30 +172,3 @@ func Get(key string) (*Option, error) {
 
 	return s, nil
 }
-
-// func importFlags(visitall bool) {
-// 	setter := func(f *flag.Flag) {
-// 		if v, exists := baseOptionSet.Get(f.Name); exists {
-// 			var val interface{}
-
-// 			switch v.flag.(type) {
-// 			case *string:
-// 				val = *(v.flag.(*string))
-// 			case *int64:
-// 				val = *(v.flag.(*int64))
-// 			case *float64:
-// 				val = *(v.flag.(*float64))
-// 			case *bool:
-// 				val = *(v.flag.(*bool))
-// 			}
-
-// 			v.Value = val
-// 		}
-// 	}
-
-// 	if visitall {
-// 		configFlags.VisitAll(setter)
-// 	} else {
-// 		configFlags.Visit(setter)
-// 	}
-// }

--- a/config_test.go
+++ b/config_test.go
@@ -27,6 +27,8 @@ func init() {
 
 	os.Args = test_args
 
+	output_writer, _ = os.OpenFile(os.DevNull, os.O_RDWR, 0700)
+
 	_ = fmt.Printf
 }
 

--- a/flag_set.go
+++ b/flag_set.go
@@ -75,7 +75,6 @@ func (f *FlagSet) parseOne() (seen bool, err error) {
 				f.args = f.unparsed[1:]
 				f.unparsed = []string{}
 			}
-
 			return false, nil
 		}
 	}
@@ -103,8 +102,8 @@ func (f *FlagSet) parseOne() (seen bool, err error) {
 	}
 
 	if option, exists := baseOptionSet[name]; exists {
+		f.unparsed = f.unparsed[1:]
 		if has_value {
-			f.unparsed = f.unparsed[1:]
 			// the option exists, and we have a value, so we can set it
 			err := option.SetFromString(value)
 			if err != nil {
@@ -113,7 +112,6 @@ func (f *FlagSet) parseOne() (seen bool, err error) {
 
 		} else if option.Type.Kind() == reflect.Bool {
 			// don't need a value, and we're not allowed to use two args, so we can set the value to true normally and continue
-			f.unparsed = f.unparsed[1:]
 			option.Value = true
 			return true, nil
 		} else {

--- a/flag_set.go
+++ b/flag_set.go
@@ -1,0 +1,167 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type errUndefinedFlag struct {
+	name string
+}
+
+type FlagSet struct {
+	name string
+
+	args     []string
+	unparsed []string
+	notset   []string
+
+	triggerErrorUndefined bool
+
+	help_flag bool
+}
+
+func NewFlagSet(name string, args []string) (f FlagSet) {
+	f.name = name
+	f.unparsed = args
+	f.triggerErrorUndefined = true
+	return
+}
+
+func (f *FlagSet) Parse() error {
+	for {
+		seen, err := f.parseOne()
+		if seen {
+			continue
+		}
+		if err == nil {
+			break
+		}
+
+		if _, ok := err.(errUndefinedFlag); ok && f.triggerErrorUndefined {
+			return err
+		}
+	}
+
+	// fmt.Println("args", f.args)
+	// fmt.Println("unparsed", f.unparsed)
+	// fmt.Println("notset", f.notset)
+
+	// pr, _ := json.MarshalIndent(baseOptionSet.Export(), "", "  ")
+	// fmt.Println(string(pr))
+
+	return nil
+}
+
+func (f *FlagSet) parseOne() (seen bool, err error) {
+	if len(f.unparsed) == 0 {
+		return false, nil
+	}
+
+	arg := f.unparsed[0]
+	if len(arg) == 0 || arg[0] != '-' || len(arg) == 1 {
+		if len(f.unparsed) > 0 {
+			f.args = f.unparsed[0:]
+			f.unparsed = []string{}
+		}
+		return false, nil
+	}
+
+	num_minuses := 1
+	if arg[1] == '-' {
+		num_minuses++
+		if len(arg) == 2 {
+			if len(f.unparsed) > 0 {
+				f.args = f.unparsed[1:]
+				f.unparsed = []string{}
+			}
+
+			return false, nil
+		}
+	}
+
+	name := arg[num_minuses:]
+	if len(name) == 0 || name[0] == '-' || name[0] == '=' {
+		return false, fmt.Errorf("bad flag syntax: %s", arg)
+	}
+
+	has_value := false
+	value := ""
+	for i := 1; i < len(name); i++ { // equals cannot be first
+		if name[i] == '=' {
+			value = name[i+1:]
+			has_value = true
+			name = name[0:i]
+			break
+		}
+	}
+
+	// the help flag is special, so we'll stop parsing flags
+	if name == "help" || name == "h" {
+		f.help_flag = true
+		return false, nil
+	}
+
+	if option, exists := baseOptionSet[name]; exists {
+		if has_value {
+			f.unparsed = f.unparsed[1:]
+			// the option exists, and we have a value, so we can set it
+			err := option.SetFromString(value)
+			if err != nil {
+				return true, fmt.Errorf("Error setting option %s to %s: %s", name, value, err)
+			}
+
+		} else if option.Type.Kind() == reflect.Bool {
+			// don't need a value, and we're not allowed to use two args, so we can set the value to true normally and continue
+			f.unparsed = f.unparsed[1:]
+			option.Value = true
+			return true, nil
+		} else {
+			// we need a value and don't have one yet, so we need to check the next argument
+			if !has_value && len(f.unparsed) > 0 {
+				// value is the next arg
+				has_value = true
+				value = f.unparsed[0]
+				f.unparsed = f.unparsed[1:]
+
+				err := option.SetFromString(value)
+				if err != nil {
+					return true, fmt.Errorf("Error setting option %s to %s: %s", name, value, err)
+				}
+			}
+
+			if !has_value {
+				return false, fmt.Errorf("flag needs an argument: -%s", name)
+			}
+		}
+	} else {
+		f.unparsed = f.unparsed[1:]
+
+		if has_value {
+			f.notset = append(f.notset, fmt.Sprintf("-%s=%s", name, value))
+		} else if len(f.unparsed) > 0 {
+			value = f.unparsed[0]
+			f.unparsed = f.unparsed[1:]
+			f.notset = append(f.notset, fmt.Sprintf("-%s", name), fmt.Sprintf("%s", value))
+		}
+
+		return true, errUndefinedFlag{name: name}
+	}
+
+	return true, nil
+}
+
+func (f FlagSet) ShowHelp() bool {
+	return f.help_flag
+}
+
+func (f FlagSet) Release() []string {
+	args := []string{f.name}
+	args = append(args, f.notset...)
+	args = append(args, f.args...)
+	return args
+}
+
+func (e errUndefinedFlag) Error() string {
+	return fmt.Sprintf("Undefined flag: -%s", e.name)
+}

--- a/io.go
+++ b/io.go
@@ -35,7 +35,7 @@ func (this FileIO) Write() error {
 	return nil
 }
 
-func (this *FileIO) Read() (err error) {
+func (this FileIO) Read() (err error) {
 	fp, err := os.Open(this.Filename)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/option.go
+++ b/option.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 )
 
 // Holds information for a configuration option
@@ -66,21 +67,36 @@ func (this Option) DefaultValueString() string {
 	return ""
 }
 
-// func (this Option) ForceString() string {
+func (this *Option) SetFromString(val string) (err error) {
+	switch this.Type.Kind() {
+	case reflect.String:
+		this.Value = val
 
-// 	switch this.Type.Kind() {
-// 	case reflect.String:
-// 		return fmt.Sprintf(`%v`, this.String())
-// 	case reflect.Int64:
-// 		return fmt.Sprintf(`%v`, this.Int())
-// 	case reflect.Float64:
-// 		return fmt.Sprintf(`%v`, this.Float())
-// 	case reflect.Bool:
-// 		return fmt.Sprintf(`%v`, this.Bool())
-// 	}
+	case reflect.Int64:
+		v, err := strconv.ParseInt(val, 0, 64)
+		if err == nil {
+			this.Value = v
+		}
 
-// 	return ""
-// }
+	case reflect.Float64:
+		v, err := strconv.ParseFloat(val, 64)
+		if err == nil {
+			this.Value = v
+		}
+
+	case reflect.Bool:
+		switch val {
+		case "1", "t", "T", "true", "TRUE", "True":
+			this.Value = true
+		case "0", "f", "F", "false", "FALSE", "False":
+			this.Value = false
+		default:
+			err = fmt.Errorf("Invalid boolean value: %s", val)
+		}
+	}
+
+	return
+}
 
 type SortedOptionSlice []Option
 

--- a/usage.go
+++ b/usage.go
@@ -2,9 +2,12 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sort"
 )
+
+var output_writer io.Writer = os.Stdout
 
 func Usage() {
 	max_len := 0
@@ -19,11 +22,11 @@ func Usage() {
 
 	sort.Sort(SortedOptionSlice(opts))
 
-	fmt.Printf("%s\n", os.Args[0])
+	fmt.Fprintf(output_writer, "%s\n", os.Args[0])
 
 	fmt_str := fmt.Sprintf("  -%%-%ds  %%s\n", max_len)
 	for _, opt := range opts {
-		fmt.Printf(fmt_str,
+		fmt.Fprintf(output_writer, fmt_str,
 			fmt.Sprintf("%s=%s", opt.Name, opt.DefaultValueString()),
 			opt.Description,
 		)

--- a/usage.go
+++ b/usage.go
@@ -7,9 +7,18 @@ import (
 	"sort"
 )
 
-var output_writer io.Writer = os.Stdout
+var UsageWriter io.Writer = os.Stdout
 
 func Usage() {
+
+	uprintf := func(fmt_str string, args ...interface{}) {
+		fmt.Fprintf(UsageWriter, fmt_str, args...)
+	}
+
+	uprintln := func(fmt_str string, args ...interface{}) {
+		uprintf(fmt_str+"\n", args...)
+	}
+
 	max_len := 0
 	opts := []Option{}
 	for _, opt := range baseOptionSet {
@@ -22,11 +31,11 @@ func Usage() {
 
 	sort.Sort(SortedOptionSlice(opts))
 
-	fmt.Fprintf(output_writer, "%s\n", os.Args[0])
+	uprintln(`%s`, os.Args[0])
 
-	fmt_str := fmt.Sprintf("  -%%-%ds  %%s\n", max_len)
+	fmt_str := fmt.Sprintf(`  -%%-%ds  %%s`, max_len)
 	for _, opt := range opts {
-		fmt.Fprintf(output_writer, fmt_str,
+		uprintln(fmt_str,
 			fmt.Sprintf("%s=%s", opt.Name, opt.DefaultValueString()),
 			opt.Description,
 		)


### PR DESCRIPTION
Using a homegrown flag parser* instead of package `flag`'s to be more lenient about missing flag definitions. 


<sup>\* heavily inspired by package `flag`'s parser</sup>