### PR TITLE
Expanded config option options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ import (
 )
 
 func main() {
-	config.Add(config.Int("addend.a", 10, "The first addend", true))
-	config.Add(config.Float("addend.b", math.Pi, "The second addend", true))
-	config.Add(config.Bool("subtract", false, "Subtract instead of add", true))
+	config.Add(config.Int("addend.a", 10, "The first addend").Exportable(true))
+	config.Add(config.Float("addend.b", math.Pi, "The second addend").Exportable(true))
+	config.Add(config.Bool("subtract", false, "Subtract instead of add").Exportable(true))
 
 	config.Build()
 

--- a/config.go
+++ b/config.go
@@ -27,8 +27,15 @@ func DefaultString(name, defaultValue string, description string) *Option {
 }
 
 // String creates an Option with the parameters given of type string
-func String(name string, defaultValue string, description string, opt_mask int) *Option {
-	opt := Option{
+func String(name string, defaultValue string, description string, optMask OptionMask) *Option {
+
+	opt := getOptionMetaFromMask(optMask)
+	opt.Filters = append(opt.Filters, func(v *Option) bool {
+		s := v.String()
+		return s != ""
+	})
+
+	v := Option{
 		Name:        name,
 		Description: description,
 
@@ -36,10 +43,10 @@ func String(name string, defaultValue string, description string, opt_mask int) 
 		Value:        defaultValue,
 		Type:         reflect.TypeOf(defaultValue),
 
-		Options: ConfigOptionFromMask(opt_mask),
+		Options: opt,
 	}
 
-	return &opt
+	return &v
 }
 
 // DefaultBool creates an Option with the parameters given of type bool and default options
@@ -48,8 +55,8 @@ func DefaultBool(name string, defaultValue bool, description string) *Option {
 }
 
 // Bool creates an Option with the parameters given of type bool
-func Bool(name string, defaultValue bool, description string, opt_mask int) *Option {
-	opt := Option{
+func Bool(name string, defaultValue bool, description string, optMask OptionMask) *Option {
+	v := Option{
 		Name:        name,
 		Description: description,
 
@@ -57,10 +64,10 @@ func Bool(name string, defaultValue bool, description string, opt_mask int) *Opt
 		Value:        defaultValue,
 		Type:         reflect.TypeOf(defaultValue),
 
-		Options: ConfigOptionFromMask(opt_mask),
+		Options: getOptionMetaFromMask(optMask),
 	}
 
-	return &opt
+	return &v
 }
 
 // DefaultInt creates an Option with the parameters given of type int64 and default options
@@ -69,8 +76,8 @@ func DefaultInt(name string, defaultValue int64, description string) *Option {
 }
 
 // Int creates an Option with the parameters given of type int64
-func Int(name string, defaultValue int64, description string, opt_mask int) *Option {
-	opt := Option{
+func Int(name string, defaultValue int64, description string, optMask OptionMask) *Option {
+	v := Option{
 		Name:        name,
 		Description: description,
 
@@ -78,10 +85,10 @@ func Int(name string, defaultValue int64, description string, opt_mask int) *Opt
 		Value:        defaultValue,
 		Type:         reflect.TypeOf(defaultValue),
 
-		Options: ConfigOptionFromMask(opt_mask),
+		Options: getOptionMetaFromMask(optMask),
 	}
 
-	return &opt
+	return &v
 }
 
 // DefaultFloat creates an Option with the parameters given of type float64 and default options
@@ -90,8 +97,8 @@ func DefaultFloat(name string, defaultValue float64, description string) *Option
 }
 
 // Float creates an Option with the parameters given of type float64
-func Float(name string, defaultValue float64, description string, opt_mask int) *Option {
-	opt := Option{
+func Float(name string, defaultValue float64, description string, optMask OptionMask) *Option {
+	v := Option{
 		Name:        name,
 		Description: description,
 
@@ -99,10 +106,10 @@ func Float(name string, defaultValue float64, description string, opt_mask int) 
 		Value:        defaultValue,
 		Type:         reflect.TypeOf(defaultValue),
 
-		Options: ConfigOptionFromMask(opt_mask),
+		Options: getOptionMetaFromMask(optMask),
 	}
 
-	return &opt
+	return &v
 }
 
 // Add adds an Option to the config's OptionSet

--- a/config.go
+++ b/config.go
@@ -23,17 +23,13 @@ func resetBaseOptionSet() {
 
 // DefaultString creates an Option with the parameters given of type string and default options
 func DefaultString(name, defaultValue string, description string) *Option {
-	return String(name, defaultValue, description, 0)
+	return String(name, defaultValue, description, DefaultOptionMeta)
 }
 
 // String creates an Option with the parameters given of type string
-func String(name string, defaultValue string, description string, optMask OptionMask) *Option {
+func String(name string, defaultValue string, description string, meta OptionMeta) *Option {
 
-	opt := getOptionMetaFromMask(optMask)
-	opt.Filters = append(opt.Filters, func(v *Option) bool {
-		s := v.String()
-		return s != ""
-	})
+	meta.Filters = append(meta.Filters, validString())
 
 	v := Option{
 		Name:        name,
@@ -43,7 +39,7 @@ func String(name string, defaultValue string, description string, optMask Option
 		Value:        defaultValue,
 		Type:         reflect.TypeOf(defaultValue),
 
-		Options: opt,
+		Options: meta,
 	}
 
 	return &v
@@ -51,11 +47,11 @@ func String(name string, defaultValue string, description string, optMask Option
 
 // DefaultBool creates an Option with the parameters given of type bool and default options
 func DefaultBool(name string, defaultValue bool, description string) *Option {
-	return Bool(name, defaultValue, description, 0)
+	return Bool(name, defaultValue, description, DefaultOptionMeta)
 }
 
 // Bool creates an Option with the parameters given of type bool
-func Bool(name string, defaultValue bool, description string, optMask OptionMask) *Option {
+func Bool(name string, defaultValue bool, description string, meta OptionMeta) *Option {
 	v := Option{
 		Name:        name,
 		Description: description,
@@ -64,7 +60,7 @@ func Bool(name string, defaultValue bool, description string, optMask OptionMask
 		Value:        defaultValue,
 		Type:         reflect.TypeOf(defaultValue),
 
-		Options: getOptionMetaFromMask(optMask),
+		Options: meta,
 	}
 
 	return &v
@@ -72,11 +68,11 @@ func Bool(name string, defaultValue bool, description string, optMask OptionMask
 
 // DefaultInt creates an Option with the parameters given of type int64 and default options
 func DefaultInt(name string, defaultValue int64, description string) *Option {
-	return Int(name, defaultValue, description, 0)
+	return Int(name, defaultValue, description, DefaultOptionMeta)
 }
 
 // Int creates an Option with the parameters given of type int64
-func Int(name string, defaultValue int64, description string, optMask OptionMask) *Option {
+func Int(name string, defaultValue int64, description string, meta OptionMeta) *Option {
 	v := Option{
 		Name:        name,
 		Description: description,
@@ -85,7 +81,7 @@ func Int(name string, defaultValue int64, description string, optMask OptionMask
 		Value:        defaultValue,
 		Type:         reflect.TypeOf(defaultValue),
 
-		Options: getOptionMetaFromMask(optMask),
+		Options: meta,
 	}
 
 	return &v
@@ -93,11 +89,11 @@ func Int(name string, defaultValue int64, description string, optMask OptionMask
 
 // DefaultFloat creates an Option with the parameters given of type float64 and default options
 func DefaultFloat(name string, defaultValue float64, description string) *Option {
-	return Float(name, defaultValue, description, 0)
+	return Float(name, defaultValue, description, DefaultOptionMeta)
 }
 
 // Float creates an Option with the parameters given of type float64
-func Float(name string, defaultValue float64, description string, optMask OptionMask) *Option {
+func Float(name string, defaultValue float64, description string, meta OptionMeta) *Option {
 	v := Option{
 		Name:        name,
 		Description: description,
@@ -106,7 +102,28 @@ func Float(name string, defaultValue float64, description string, optMask Option
 		Value:        defaultValue,
 		Type:         reflect.TypeOf(defaultValue),
 
-		Options: getOptionMetaFromMask(optMask),
+		Options: meta,
+	}
+
+	return &v
+}
+
+// Enum creates an Option with the parameters given of type string
+func Enum(name string, possibleValues []string, defaultValue string, description string, meta OptionMeta) *Option {
+
+	meta.Filters = append(meta.Filters, validEnum(possibleValues))
+
+	meta.Required = true
+
+	v := Option{
+		Name:        name,
+		Description: description,
+
+		DefaultValue: reflect.ValueOf(defaultValue),
+		Value:        defaultValue,
+		Type:         reflect.TypeOf(defaultValue),
+
+		Options: meta,
 	}
 
 	return &v

--- a/config.go
+++ b/config.go
@@ -16,14 +16,18 @@ func init() {
 
 func resetBaseOptionSet() {
 	baseOptionSet = make(OptionSet)
-	Add(String("config", "config.json", "The filename of the config file to use", false))
-	Add(Bool("config-export", false, "Export the as-run configuration to a file", false))
-	Add(Bool("config-generate", false, "Export the as-run configuration to a file, then exit", false))
+	Add(DefaultString("config", "config.json", "The filename of the config file to use"))
+	Add(DefaultBool("config-export", false, "Export the as-run configuration to a file"))
+	Add(DefaultBool("config-generate", false, "Export the as-run configuration to a file, then exit"))
+}
+
+// DefaultString creates an Option with the parameters given of type string and default options
+func DefaultString(name, defaultValue string, description string) *Option {
+	return String(name, defaultValue, description, 0)
 }
 
 // String creates an Option with the parameters given of type string
-func String(name string, defaultValue string, description string, exportable bool) *Option {
-
+func String(name string, defaultValue string, description string, opt_mask int) *Option {
 	opt := Option{
 		Name:        name,
 		Description: description,
@@ -32,15 +36,19 @@ func String(name string, defaultValue string, description string, exportable boo
 		Value:        defaultValue,
 		Type:         reflect.TypeOf(defaultValue),
 
-		Exportable: exportable,
+		Options: ConfigOptionFromMask(opt_mask),
 	}
 
 	return &opt
+}
+
+// DefaultBool creates an Option with the parameters given of type bool and default options
+func DefaultBool(name string, defaultValue bool, description string) *Option {
+	return Bool(name, defaultValue, description, 0)
 }
 
 // Bool creates an Option with the parameters given of type bool
-func Bool(name string, defaultValue bool, description string, exportable bool) *Option {
-
+func Bool(name string, defaultValue bool, description string, opt_mask int) *Option {
 	opt := Option{
 		Name:        name,
 		Description: description,
@@ -49,15 +57,19 @@ func Bool(name string, defaultValue bool, description string, exportable bool) *
 		Value:        defaultValue,
 		Type:         reflect.TypeOf(defaultValue),
 
-		Exportable: exportable,
+		Options: ConfigOptionFromMask(opt_mask),
 	}
 
 	return &opt
+}
+
+// DefaultInt creates an Option with the parameters given of type int64 and default options
+func DefaultInt(name string, defaultValue int64, description string) *Option {
+	return Int(name, defaultValue, description, 0)
 }
 
 // Int creates an Option with the parameters given of type int64
-func Int(name string, defaultValue int64, description string, exportable bool) *Option {
-
+func Int(name string, defaultValue int64, description string, opt_mask int) *Option {
 	opt := Option{
 		Name:        name,
 		Description: description,
@@ -66,15 +78,19 @@ func Int(name string, defaultValue int64, description string, exportable bool) *
 		Value:        defaultValue,
 		Type:         reflect.TypeOf(defaultValue),
 
-		Exportable: exportable,
+		Options: ConfigOptionFromMask(opt_mask),
 	}
 
 	return &opt
 }
 
-// Float creates an Option with the parameters given of type float64
-func Float(name string, defaultValue float64, description string, exportable bool) *Option {
+// DefaultFloat creates an Option with the parameters given of type float64 and default options
+func DefaultFloat(name string, defaultValue float64, description string) *Option {
+	return Float(name, defaultValue, description, 0)
+}
 
+// Float creates an Option with the parameters given of type float64
+func Float(name string, defaultValue float64, description string, opt_mask int) *Option {
 	opt := Option{
 		Name:        name,
 		Description: description,
@@ -83,7 +99,7 @@ func Float(name string, defaultValue float64, description string, exportable boo
 		Value:        defaultValue,
 		Type:         reflect.TypeOf(defaultValue),
 
-		Exportable: exportable,
+		Options: ConfigOptionFromMask(opt_mask),
 	}
 
 	return &opt
@@ -126,6 +142,12 @@ func Build() error {
 		Usage()
 		os.Exit(0)
 		return nil
+	}
+
+	// validate all options that are required
+	err = baseOptionSet.Validate()
+	if err != nil {
+		return err
 	}
 
 	// export new config to file if necessary

--- a/config.go
+++ b/config.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"reflect"
 )
 
 var baseOptionSet OptionSet
@@ -16,117 +15,9 @@ func init() {
 
 func resetBaseOptionSet() {
 	baseOptionSet = make(OptionSet)
-	Add(DefaultString("config", "config.json", "The filename of the config file to use"))
-	Add(DefaultBool("config-export", false, "Export the as-run configuration to a file"))
-	Add(DefaultBool("config-generate", false, "Export the as-run configuration to a file, then exit"))
-}
-
-// DefaultString creates an Option with the parameters given of type string and default options
-func DefaultString(name, defaultValue string, description string) *Option {
-	return String(name, defaultValue, description, DefaultOptionMeta)
-}
-
-// String creates an Option with the parameters given of type string
-func String(name string, defaultValue string, description string, meta OptionMeta) *Option {
-
-	meta.Filters = append(meta.Filters, validString())
-
-	v := Option{
-		Name:        name,
-		Description: description,
-
-		DefaultValue: reflect.ValueOf(defaultValue),
-		Value:        defaultValue,
-		Type:         reflect.TypeOf(defaultValue),
-
-		Options: meta,
-	}
-
-	return &v
-}
-
-// DefaultBool creates an Option with the parameters given of type bool and default options
-func DefaultBool(name string, defaultValue bool, description string) *Option {
-	return Bool(name, defaultValue, description, DefaultOptionMeta)
-}
-
-// Bool creates an Option with the parameters given of type bool
-func Bool(name string, defaultValue bool, description string, meta OptionMeta) *Option {
-	v := Option{
-		Name:        name,
-		Description: description,
-
-		DefaultValue: reflect.ValueOf(defaultValue),
-		Value:        defaultValue,
-		Type:         reflect.TypeOf(defaultValue),
-
-		Options: meta,
-	}
-
-	return &v
-}
-
-// DefaultInt creates an Option with the parameters given of type int64 and default options
-func DefaultInt(name string, defaultValue int64, description string) *Option {
-	return Int(name, defaultValue, description, DefaultOptionMeta)
-}
-
-// Int creates an Option with the parameters given of type int64
-func Int(name string, defaultValue int64, description string, meta OptionMeta) *Option {
-	v := Option{
-		Name:        name,
-		Description: description,
-
-		DefaultValue: reflect.ValueOf(defaultValue),
-		Value:        defaultValue,
-		Type:         reflect.TypeOf(defaultValue),
-
-		Options: meta,
-	}
-
-	return &v
-}
-
-// DefaultFloat creates an Option with the parameters given of type float64 and default options
-func DefaultFloat(name string, defaultValue float64, description string) *Option {
-	return Float(name, defaultValue, description, DefaultOptionMeta)
-}
-
-// Float creates an Option with the parameters given of type float64
-func Float(name string, defaultValue float64, description string, meta OptionMeta) *Option {
-	v := Option{
-		Name:        name,
-		Description: description,
-
-		DefaultValue: reflect.ValueOf(defaultValue),
-		Value:        defaultValue,
-		Type:         reflect.TypeOf(defaultValue),
-
-		Options: meta,
-	}
-
-	return &v
-}
-
-// Enum creates an Option with the parameters given of type string
-func Enum(name string, possibleValues []string, defaultValue string, description string, meta OptionMeta) *Option {
-
-	meta.Filters = append(meta.Filters, validEnum(possibleValues))
-
-	meta.Required = true
-
-	v := Option{
-		Name:        name,
-		Description: description,
-
-		DefaultValue: reflect.ValueOf(defaultValue),
-		Value:        defaultValue,
-		Type:         reflect.TypeOf(defaultValue),
-
-		Options: meta,
-	}
-
-	return &v
+	Add(String("config", "config.json", "The filename of the config file to use"))
+	Add(Bool("config-export", false, "Export the as-run configuration to a file"))
+	Add(Bool("config-generate", false, "Export the as-run configuration to a file, then exit"))
 }
 
 // Add adds an Option to the config's OptionSet

--- a/config_test.go
+++ b/config_test.go
@@ -60,10 +60,10 @@ func TestBasicConfigLoad(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", true))
-	Add(Float("addend.b", math.Pi, "The second addend", true))
-	Add(Bool("subtract", false, "Subtract instead of add", true))
-	Add(String("name", "Basic Example", "Name of the example", true))
+	Add(Int("addend.a", 10, "The first addend", Exportable))
+	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
+	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
+	Add(String("name", "Basic Example", "Name of the example", Exportable))
 
 	resetArgs()
 
@@ -125,10 +125,10 @@ func TestErroredConfigLoad(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", true))
-	Add(Float("addend.b", math.Pi, "The second addend", true))
-	Add(Bool("subtract", false, "Subtract instead of add", true))
-	Add(String("name", "Basic Example", "Name of the example", true))
+	Add(Int("addend.a", 10, "The first addend", Exportable))
+	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
+	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
+	Add(String("name", "Basic Example", "Name of the example", Exportable))
 
 	resetArgs()
 
@@ -168,10 +168,10 @@ func TestBasicConfigLoadWithFlags(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", true))
-	Add(Float("addend.b", math.Pi, "The second addend", true))
-	Add(Bool("subtract", false, "Subtract instead of add", true))
-	Add(String("name", "Basic Example", "Name of the example", true))
+	Add(Int("addend.a", 10, "The first addend", Exportable|Required))
+	Add(Float("addend.b", math.Pi, "The second addend", Exportable|Required))
+	Add(Bool("subtract", false, "Subtract instead of add", Exportable|Required))
+	Add(String("name", "Basic Example", "Name of the example", Exportable|Required))
 
 	// and here we go!
 	os.Args = []string{
@@ -237,10 +237,10 @@ func TestBasicConfigLoadWithOtherFlags(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", true))
-	Add(Float("addend.b", math.Pi, "The second addend", true))
-	Add(Bool("subtract", false, "Subtract instead of add", true))
-	Add(String("name", "Basic Example", "Name of the example", true))
+	Add(Int("addend.a", 10, "The first addend", Exportable))
+	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
+	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
+	Add(String("name", "Basic Example", "Name of the example", Exportable))
 
 	// and here we go!
 	os.Args = []string{
@@ -312,10 +312,10 @@ func TestBasicConfigLoadWithFinalBooleanFlag(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", true))
-	Add(Float("addend.b", math.Pi, "The second addend", true))
-	Add(Bool("subtract", false, "Subtract instead of add", true))
-	Add(String("name", "Basic Example", "Name of the example", true))
+	Add(Int("addend.a", 10, "The first addend", Exportable))
+	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
+	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
+	Add(String("name", "Basic Example", "Name of the example", Exportable))
 
 	// and here we go!
 	os.Args = []string{
@@ -386,10 +386,10 @@ func TestBasicConfigLoadWithUndefinedFlags(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", true))
-	Add(Float("addend.b", math.Pi, "The second addend", true))
-	Add(Bool("subtract", false, "Subtract instead of add", true))
-	Add(String("name", "Basic Example", "Name of the example", true))
+	Add(Int("addend.a", 10, "The first addend", Exportable))
+	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
+	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
+	Add(String("name", "Basic Example", "Name of the example", Exportable))
 
 	// and here we go!
 	os.Args = []string{
@@ -466,10 +466,10 @@ func TestBasicConfigWrite(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", true))
-	Add(Float("addend.b", math.Pi, "The second addend", true))
-	Add(Bool("subtract", false, "Subtract instead of add", true))
-	Add(String("name", "Basic Example", "Name of the example", true))
+	Add(Int("addend.a", 10, "The first addend", Exportable))
+	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
+	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
+	Add(String("name", "Basic Example", "Name of the example", Exportable))
 
 	os.Args = []string{
 		`go-config`,
@@ -493,10 +493,10 @@ func TestBasicConfigWrite(t *testing.T) {
 	resetBaseOptionSet()
 	baseOptionSet.Require("config").SetFromString(filepath)
 
-	Add(Int("addend.a", 10, "The first addend", true))
-	Add(Float("addend.b", math.Pi, "The second addend", true))
-	Add(Bool("subtract", false, "Subtract instead of add", true))
-	Add(String("name", "Basic Example", "Name of the example", true))
+	Add(Int("addend.a", 10, "The first addend", Exportable))
+	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
+	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
+	Add(String("name", "Basic Example", "Name of the example", Exportable))
 
 	resetArgs()
 

--- a/config_test.go
+++ b/config_test.go
@@ -11,10 +11,12 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path"
 )
 
 var originalOSArgs []string
 var originalFlagSet *flag.FlagSet
+var tempDir string
 
 func init() {
 	// defined in usage.go, just tells Usage() where to direct output.
@@ -25,7 +27,13 @@ func init() {
 	originalOSArgs = os.Args
 	originalFlagSet = flag.CommandLine
 
-	_ = fmt.Printf
+	tempDir = path.Clean(os.TempDir() + "/go-config")
+
+	err := os.MkdirAll(tempDir, 0775)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating temporary directory: %s\n", err)
+		os.Exit(2)
+	}
 }
 
 func resetArgs() {
@@ -44,11 +52,11 @@ func TestBasicConfigLoad(t *testing.T) {
     "name": "Basic Example"
 }`)
 
-	filepath := os.TempDir() + "/go-config-basic-config.json"
+	filepath := tempDir + "/go-config-basic-config.json"
 
 	fp, err := os.OpenFile(filepath, os.O_RDWR+os.O_CREATE+os.O_TRUNC, 0644)
 	if err != nil {
-		t.Errorf("Couldn't open temporary config file")
+		t.Errorf("Couldn't open temporary config file at %s: %s", filepath, err)
 		t.FailNow()
 	}
 
@@ -60,10 +68,10 @@ func TestBasicConfigLoad(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
-	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
-	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
-	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
+	Add(Int("addend.a", 10, "The first addend").Exportable(true))
+	Add(Float("addend.b", math.Pi, "The second addend").Exportable(true))
+	Add(Bool("subtract", false, "Subtract instead of add").Exportable(true))
+	Add(String("name", "Basic Example", "Name of the example").Exportable(true))
 
 	resetArgs()
 
@@ -109,11 +117,11 @@ func TestRequiredConfigLoad(t *testing.T) {
     "param-2": "provided"
 }`)
 
-	filepath := os.TempDir() + "/go-config-required-config.json"
+	filepath := tempDir + "/go-config-required-config.json"
 
 	fp, err := os.OpenFile(filepath, os.O_RDWR+os.O_CREATE+os.O_TRUNC, 0644)
 	if err != nil {
-		t.Errorf("Couldn't open temporary config file")
+		t.Errorf("Couldn't open temporary config file at %s: %s", filepath, err)
 		t.FailNow()
 	}
 
@@ -125,11 +133,11 @@ func TestRequiredConfigLoad(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
-	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
-	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
-	Add(String("param-1", "Value 1", "Name of the example", OptionMeta{Exportable: true, Required: true}))
-	Add(String("param-2", "Value 2", "", OptionMeta{Exportable: true, Required: true}))
+	Add(Int("addend.a", 10, "The first addend").Exportable(true))
+	Add(Float("addend.b", math.Pi, "The second addend").Exportable(true))
+	Add(Bool("subtract", false, "Subtract instead of add").Exportable(true))
+	Add(String("param-1", "Value 1", "Name of the example").Exportable(true).AddFilter(NonEmptyString()))
+	Add(String("param-2", "Value 2", "").Exportable(true).AddFilter(NonEmptyString()))
 
 	resetArgs()
 
@@ -179,11 +187,11 @@ func TestErroredConfigLoad(t *testing.T) {
     "name": false
 }`)
 
-	filepath := os.TempDir() + "/go-config-basic-config.json"
+	filepath := tempDir + "/go-config-basic-config.json"
 
 	fp, err := os.OpenFile(filepath, os.O_RDWR+os.O_CREATE+os.O_TRUNC, 0644)
 	if err != nil {
-		t.Errorf("Couldn't open temporary config file")
+		t.Errorf("Couldn't open temporary config file at %s: %s", filepath, err)
 		t.FailNow()
 	}
 
@@ -195,10 +203,10 @@ func TestErroredConfigLoad(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
-	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
-	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
-	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
+	Add(Int("addend.a", 10, "The first addend").Exportable(true))
+	Add(Float("addend.b", math.Pi, "The second addend").Exportable(true))
+	Add(Bool("subtract", false, "Subtract instead of add").Exportable(true))
+	Add(String("name", "Basic Example", "Name of the example").Exportable(true))
 
 	resetArgs()
 
@@ -222,11 +230,11 @@ func TestBasicConfigLoadWithFlags(t *testing.T) {
     "name": "Basic Example"
 }`)
 
-	filepath := os.TempDir() + "/go-config-basic-config.json"
+	filepath := tempDir + "/go-config-basic-config.json"
 
 	fp, err := os.OpenFile(filepath, os.O_RDWR+os.O_CREATE+os.O_TRUNC, 0644)
 	if err != nil {
-		t.Errorf("Couldn't open temporary config file")
+		t.Errorf("Couldn't open temporary config file at %s: %s", filepath, err)
 		t.FailNow()
 	}
 
@@ -238,10 +246,10 @@ func TestBasicConfigLoadWithFlags(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
-	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
-	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
-	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
+	Add(Int("addend.a", 10, "The first addend").Exportable(true))
+	Add(Float("addend.b", math.Pi, "The second addend").Exportable(true))
+	Add(Bool("subtract", false, "Subtract instead of add").Exportable(true))
+	Add(String("name", "Basic Example", "Name of the example").Exportable(true))
 
 	// and here we go!
 	os.Args = []string{
@@ -291,11 +299,11 @@ func TestBasicConfigLoadWithOtherFlags(t *testing.T) {
     "name": "Basic Example"
 }`)
 
-	filepath := os.TempDir() + "/go-config-basic-config.json"
+	filepath := tempDir + "/go-config-basic-config.json"
 
 	fp, err := os.OpenFile(filepath, os.O_RDWR+os.O_CREATE+os.O_TRUNC, 0644)
 	if err != nil {
-		t.Errorf("Couldn't open temporary config file")
+		t.Errorf("Couldn't open temporary config file at %s: %s", filepath, err)
 		t.FailNow()
 	}
 
@@ -307,10 +315,10 @@ func TestBasicConfigLoadWithOtherFlags(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
-	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
-	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
-	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
+	Add(Int("addend.a", 10, "The first addend").Exportable(true))
+	Add(Float("addend.b", math.Pi, "The second addend").Exportable(true))
+	Add(Bool("subtract", false, "Subtract instead of add").Exportable(true))
+	Add(String("name", "Basic Example", "Name of the example").Exportable(true))
 
 	// and here we go!
 	os.Args = []string{
@@ -366,11 +374,10 @@ func TestBasicConfigLoadWithFinalBooleanFlag(t *testing.T) {
     "name": "Basic Example"
 }`)
 
-	filepath := os.TempDir() + "/go-config-basic-config.json"
-
+	filepath := tempDir + "/go-config-basic-config.json"
 	fp, err := os.OpenFile(filepath, os.O_RDWR+os.O_CREATE+os.O_TRUNC, 0644)
 	if err != nil {
-		t.Errorf("Couldn't open temporary config file")
+		t.Errorf("Couldn't open temporary config file at %s: %s", filepath, err)
 		t.FailNow()
 	}
 
@@ -382,10 +389,10 @@ func TestBasicConfigLoadWithFinalBooleanFlag(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
-	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
-	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
-	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
+	Add(Int("addend.a", 10, "The first addend").Exportable(true))
+	Add(Float("addend.b", math.Pi, "The second addend").Exportable(true))
+	Add(Bool("subtract", false, "Subtract instead of add").Exportable(true))
+	Add(String("name", "Basic Example", "Name of the example").Exportable(true))
 
 	// and here we go!
 	os.Args = []string{
@@ -440,11 +447,11 @@ func TestBasicConfigLoadWithUndefinedFlags(t *testing.T) {
     "name": "Basic Example"
 }`)
 
-	filepath := os.TempDir() + "/go-config-basic-config.json"
+	filepath := tempDir + "/go-config-basic-config.json"
 
 	fp, err := os.OpenFile(filepath, os.O_RDWR+os.O_CREATE+os.O_TRUNC, 0644)
 	if err != nil {
-		t.Errorf("Couldn't open temporary config file")
+		t.Errorf("Couldn't open temporary config file at %s: %s", filepath, err)
 		t.FailNow()
 	}
 
@@ -456,10 +463,10 @@ func TestBasicConfigLoadWithUndefinedFlags(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
-	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
-	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
-	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
+	Add(Int("addend.a", 10, "The first addend").Exportable(true))
+	Add(Float("addend.b", math.Pi, "The second addend").Exportable(true))
+	Add(Bool("subtract", false, "Subtract instead of add").Exportable(true))
+	Add(String("name", "Basic Example", "Name of the example").Exportable(true))
 
 	// and here we go!
 	os.Args = []string{
@@ -520,11 +527,11 @@ func TestBasicConfigWrite(t *testing.T) {
     "subtract": true
 }`)
 
-	filepath := os.TempDir() + "/go-config-basic-config-write.json"
+	filepath := tempDir + "/go-config-basic-config-write.json"
 
 	fp, err := os.OpenFile(filepath, os.O_RDWR+os.O_CREATE+os.O_TRUNC, 0644)
 	if err != nil {
-		t.Errorf("Couldn't open temporary config file")
+		t.Errorf("Couldn't open temporary config file at %s: %s", filepath, err)
 		t.FailNow()
 	}
 
@@ -536,10 +543,10 @@ func TestBasicConfigWrite(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
-	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
-	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
-	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
+	Add(Int("addend.a", 10, "The first addend").Exportable(true))
+	Add(Float("addend.b", math.Pi, "The second addend").Exportable(true))
+	Add(Bool("subtract", false, "Subtract instead of add").Exportable(true))
+	Add(String("name", "Basic Example", "Name of the example").Exportable(true))
 
 	os.Args = []string{
 		`go-config`,
@@ -563,10 +570,10 @@ func TestBasicConfigWrite(t *testing.T) {
 	resetBaseOptionSet()
 	baseOptionSet.Require("config").SetFromString(filepath)
 
-	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
-	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
-	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
-	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
+	Add(Int("addend.a", 10, "The first addend").Exportable(true))
+	Add(Float("addend.b", math.Pi, "The second addend").Exportable(true))
+	Add(Bool("subtract", false, "Subtract instead of add").Exportable(true))
+	Add(String("name", "Basic Example", "Name of the example").Exportable(true))
 
 	resetArgs()
 
@@ -590,11 +597,11 @@ func TestEnumConfig(t *testing.T) {
     "name": "Test"
 }`)
 
-	filepath := os.TempDir() + "/go-config-enum-config.json"
+	filepath := tempDir + "/go-config-enum-config.json"
 
 	fp, err := os.OpenFile(filepath, os.O_RDWR+os.O_CREATE+os.O_TRUNC, 0644)
 	if err != nil {
-		t.Errorf("Couldn't open temporary config file")
+		t.Errorf("Couldn't open temporary config file at %s: %s", filepath, err)
 		t.FailNow()
 	}
 
@@ -606,10 +613,10 @@ func TestEnumConfig(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
-	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
-	Add(Enum("mode", []string{"subtract", "add"}, "add", "subtract or add", OptionMeta{Exportable: true}))
-	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
+	Add(Int("addend.a", 10, "The first addend").Exportable(true))
+	Add(Float("addend.b", math.Pi, "The second addend").Exportable(true))
+	Add(Enum("mode", []string{"subtract", "add"}, "add", "subtract or add").Exportable(true))
+	Add(String("name", "Basic Example", "Name of the example").Exportable(true))
 
 	err = Build()
 
@@ -640,11 +647,11 @@ func TestInvalidEnumConfig(t *testing.T) {
     "name": "Test"
 }`)
 
-	filepath := os.TempDir() + "/go-config-enum-config.json"
+	filepath := tempDir + "/go-config-enum-config.json"
 
 	fp, err := os.OpenFile(filepath, os.O_RDWR+os.O_CREATE+os.O_TRUNC, 0644)
 	if err != nil {
-		t.Errorf("Couldn't open temporary config file")
+		t.Errorf("Couldn't open temporary config file at %s: %s", filepath, err)
 		t.FailNow()
 	}
 
@@ -656,13 +663,12 @@ func TestInvalidEnumConfig(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
-	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
-	Add(Enum("mode", []string{"subtract", "add"}, "subtract", "subtract or add", OptionMeta{Exportable: true}))
-	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
+	Add(Int("addend.a", 10, "The first addend").Exportable(true))
+	Add(Float("addend.b", math.Pi, "The second addend").Exportable(true))
+	Add(Enum("mode", []string{"subtract", "add"}, "subtract", "subtract or add").Exportable(true))
+	Add(String("name", "Basic Example", "Name of the example").Exportable(true))
 
 	err = Build()
-	t.Logf("%s", err)
 
 	assert.NotNil(t, err, "There should be an error because the enum is wrong")
 }

--- a/config_test.go
+++ b/config_test.go
@@ -714,8 +714,8 @@ func TestTripleNestedOption(t *testing.T) {
 	addend_a := Require("equation.addend.a").Int()
 	addend_b := Require("equation.addend.b").Int()
 
-	assert.Equal(t, 4, addend_a, "addend_a should be 4")
-	assert.Equal(t, 2, addend_b, "addend_b should be 2")
+	assert.Equal(t, int64(4), addend_a, "addend_a should be 4")
+	assert.Equal(t, int64(2), addend_b, "addend_b should be 2")
 
-	assert.Equal(t, 2, addend_a-addend_b, "%d minus %d != 2", addend_a, addend_b)
+	assert.Equal(t, int64(2), addend_a-addend_b, "%d minus %d != 2", addend_a, addend_b)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -580,6 +580,6 @@ func TestBasicConfigWrite(t *testing.T) {
 }
 
 func TestConstants(t *testing.T) {
-	assert.Equal(t, Exportable, 1, "Exportable should be 1")
-	assert.Equal(t, Required, 2, "Required should be 2")
+	assert.Equal(t, int32(Exportable), int32(1), "Exportable should be 1")
+	assert.Equal(t, int32(Required), int32(2), "Required should be 2")
 }

--- a/config_test.go
+++ b/config_test.go
@@ -60,10 +60,10 @@ func TestBasicConfigLoad(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", Exportable))
-	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
-	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
-	Add(String("name", "Basic Example", "Name of the example", Exportable))
+	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
+	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
+	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
+	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
 
 	resetArgs()
 
@@ -125,11 +125,11 @@ func TestRequiredConfigLoad(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", Exportable))
-	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
-	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
-	Add(String("param-1", "Value 1", "Name of the example", Exportable|Required))
-	Add(String("param-2", "Value 2", "", Exportable|Required))
+	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
+	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
+	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
+	Add(String("param-1", "Value 1", "Name of the example", OptionMeta{Exportable: true, Required: true}))
+	Add(String("param-2", "Value 2", "", OptionMeta{Exportable: true, Required: true}))
 
 	resetArgs()
 
@@ -195,10 +195,10 @@ func TestErroredConfigLoad(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", Exportable))
-	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
-	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
-	Add(String("name", "Basic Example", "Name of the example", Exportable))
+	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
+	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
+	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
+	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
 
 	resetArgs()
 
@@ -238,10 +238,10 @@ func TestBasicConfigLoadWithFlags(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", Exportable))
-	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
-	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
-	Add(String("name", "Basic Example", "Name of the example", Exportable))
+	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
+	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
+	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
+	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
 
 	// and here we go!
 	os.Args = []string{
@@ -307,10 +307,10 @@ func TestBasicConfigLoadWithOtherFlags(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", Exportable))
-	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
-	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
-	Add(String("name", "Basic Example", "Name of the example", Exportable))
+	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
+	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
+	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
+	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
 
 	// and here we go!
 	os.Args = []string{
@@ -382,10 +382,10 @@ func TestBasicConfigLoadWithFinalBooleanFlag(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", Exportable))
-	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
-	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
-	Add(String("name", "Basic Example", "Name of the example", Exportable))
+	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
+	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
+	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
+	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
 
 	// and here we go!
 	os.Args = []string{
@@ -456,10 +456,10 @@ func TestBasicConfigLoadWithUndefinedFlags(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", Exportable))
-	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
-	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
-	Add(String("name", "Basic Example", "Name of the example", Exportable))
+	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
+	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
+	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
+	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
 
 	// and here we go!
 	os.Args = []string{
@@ -536,10 +536,10 @@ func TestBasicConfigWrite(t *testing.T) {
 	baseOptionSet.Require("config").SetFromString(filepath)
 
 	// setting up our config options to read the temporary config.json properly
-	Add(Int("addend.a", 10, "The first addend", Exportable))
-	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
-	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
-	Add(String("name", "Basic Example", "Name of the example", Exportable))
+	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
+	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
+	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
+	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
 
 	os.Args = []string{
 		`go-config`,
@@ -563,10 +563,10 @@ func TestBasicConfigWrite(t *testing.T) {
 	resetBaseOptionSet()
 	baseOptionSet.Require("config").SetFromString(filepath)
 
-	Add(Int("addend.a", 10, "The first addend", Exportable))
-	Add(Float("addend.b", math.Pi, "The second addend", Exportable))
-	Add(Bool("subtract", false, "Subtract instead of add", Exportable))
-	Add(String("name", "Basic Example", "Name of the example", Exportable))
+	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
+	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
+	Add(Bool("subtract", false, "Subtract instead of add", OptionMeta{Exportable: true}))
+	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
 
 	resetArgs()
 
@@ -579,7 +579,90 @@ func TestBasicConfigWrite(t *testing.T) {
 	assert.Equal(t, buf.String(), string(builtJSON), "Written config file should match expected")
 }
 
-func TestConstants(t *testing.T) {
-	assert.Equal(t, int32(Exportable), int32(1), "Exportable should be 1")
-	assert.Equal(t, int32(Required), int32(2), "Required should be 2")
+func TestEnumConfig(t *testing.T) {
+	// writing the config.json to a temporary file
+	configJSON := []byte(`{
+    "addend": {
+        "a": 4,
+        "b": 2
+    },
+    "mode": "subtract",
+    "name": "Test"
+}`)
+
+	filepath := os.TempDir() + "/go-config-enum-config.json"
+
+	fp, err := os.OpenFile(filepath, os.O_RDWR+os.O_CREATE+os.O_TRUNC, 0644)
+	if err != nil {
+		t.Errorf("Couldn't open temporary config file")
+		t.FailNow()
+	}
+
+	fp.Write(configJSON)
+	fp.Close()
+
+	// rigging the test to use our temporary config file
+	resetBaseOptionSet()
+	baseOptionSet.Require("config").SetFromString(filepath)
+
+	// setting up our config options to read the temporary config.json properly
+	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
+	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
+	Add(Enum("mode", []string{"subtract", "add"}, "add", "subtract or add", OptionMeta{Exportable: true}))
+	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
+
+	err = Build()
+
+	a := Require("addend.a").Int()
+	assert.Equal(t, a, int64(4), "addend.a should be 4")
+
+	b := Require("addend.b").Float()
+	assert.Equal(t, b, float64(2), "addend.b should be 2")
+
+	mode := Require("mode").String()
+	assert.Equal(t, mode, "subtract", "mode should be subtract")
+
+	c := float64(a) - float64(b)
+	assert.Equal(t, c, float64(4-2), "The operation on addend.a - addend.b should be 2")
+
+	name := Require("name").String()
+	assert.Equal(t, name, "Test", "Name should be \"Test\"")
+}
+
+func TestInvalidEnumConfig(t *testing.T) {
+	// writing the config.json to a temporary file
+	configJSON := []byte(`{
+    "addend": {
+        "a": 4,
+        "b": 2
+    },
+    "mode": "invalid",
+    "name": "Test"
+}`)
+
+	filepath := os.TempDir() + "/go-config-enum-config.json"
+
+	fp, err := os.OpenFile(filepath, os.O_RDWR+os.O_CREATE+os.O_TRUNC, 0644)
+	if err != nil {
+		t.Errorf("Couldn't open temporary config file")
+		t.FailNow()
+	}
+
+	fp.Write(configJSON)
+	fp.Close()
+
+	// rigging the test to use our temporary config file
+	resetBaseOptionSet()
+	baseOptionSet.Require("config").SetFromString(filepath)
+
+	// setting up our config options to read the temporary config.json properly
+	Add(Int("addend.a", 10, "The first addend", OptionMeta{Exportable: true}))
+	Add(Float("addend.b", math.Pi, "The second addend", OptionMeta{Exportable: true}))
+	Add(Enum("mode", []string{"subtract", "add"}, "subtract", "subtract or add", OptionMeta{Exportable: true}))
+	Add(String("name", "Basic Example", "Name of the example", OptionMeta{Exportable: true}))
+
+	err = Build()
+	t.Logf("%s", err)
+
+	assert.NotNil(t, err, "There should be an error because the enum is wrong")
 }

--- a/filters.go
+++ b/filters.go
@@ -1,0 +1,24 @@
+package config
+
+func validEnum(possibleValues []string) func(*Option) bool {
+	return func(v *Option) bool {
+		val := v.String()
+		for _, s := range possibleValues {
+			if val == s {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func validString() func(*Option) bool {
+	return func(v *Option) bool {
+		if v.Options.Required {
+			s := v.String()
+			return s != ""
+		} else {
+			return true
+		}
+	}
+}

--- a/filters.go
+++ b/filters.go
@@ -1,24 +1,32 @@
 package config
 
-func validEnum(possibleValues []string) func(*Option) bool {
-	return func(v *Option) bool {
+import (
+	"fmt"
+)
+
+func validEnum(possibleValues []string) func(*Option) (bool, error) {
+	return func(v *Option) (bool, error) {
 		val := v.String()
 		for _, s := range possibleValues {
 			if val == s {
-				return true
+				return true, nil
 			}
 		}
-		return false
+		return false, fmt.Errorf("invalid value for enum: %s", val)
 	}
 }
 
-func validString() func(*Option) bool {
-	return func(v *Option) bool {
-		if v.Options.Required {
-			s := v.String()
-			return s != ""
+func validString() func(*Option) (bool, error) {
+	return func(v *Option) (bool, error) {
+		if !v.Options.Required {
+			return true, nil
+		}
+
+		s := v.String()
+		if s != "" {
+			return true, nil
 		} else {
-			return true
+			return false, fmt.Errorf("empty string")
 		}
 	}
 }

--- a/filters.go
+++ b/filters.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 )
 
-func validEnum(possibleValues []string) func(*Option) (bool, error) {
+// IsOneOfStrings returns an OptionFilterFunc that checks the Option value against a list of
+// string values and returns true if the Option value matches one of the possible values
+func IsOneOfStrings(possibleValues []string) OptionFilterFunc {
 	return func(v *Option) (bool, error) {
 		val := v.String()
 		for _, s := range possibleValues {
@@ -12,21 +14,19 @@ func validEnum(possibleValues []string) func(*Option) (bool, error) {
 				return true, nil
 			}
 		}
-		return false, fmt.Errorf("invalid value for enum: %s", val)
+		return false, fmt.Errorf("%s is not contained in possible values", val)
 	}
 }
 
-func validString() func(*Option) (bool, error) {
+// NonEmptyString returns an OptionFilterFunc that returns true if the Option value is a non-empty
+// string. It will also return false if the Option is not a string.
+func NonEmptyString() OptionFilterFunc {
 	return func(v *Option) (bool, error) {
-		if !v.Options.Required {
-			return true, nil
-		}
-
 		s := v.String()
 		if s != "" {
 			return true, nil
 		} else {
-			return false, fmt.Errorf("empty string")
+			return false, fmt.Errorf("value is empty string")
 		}
 	}
 }

--- a/io_parser.go
+++ b/io_parser.go
@@ -78,8 +78,6 @@ func (j jsonConfigMapParseErrorList) Len() int {
 
 func parse(configMap map[string]interface{}, prefix string) (err error) {
 
-	fmt.Println(configMap, prefix)
-
 	errs := make(jsonConfigMapParseErrorList, 0)
 
 	for k, v := range configMap {

--- a/io_parser.go
+++ b/io_parser.go
@@ -78,6 +78,8 @@ func (j jsonConfigMapParseErrorList) Len() int {
 
 func parse(configMap map[string]interface{}, prefix string) (err error) {
 
+	fmt.Println(configMap, prefix)
+
 	errs := make(jsonConfigMapParseErrorList, 0)
 
 	for k, v := range configMap {
@@ -131,7 +133,7 @@ func parse(configMap map[string]interface{}, prefix string) (err error) {
 		} else {
 			switch v.(type) {
 			case map[string]interface{}:
-				cerr := parse(v.(map[string]interface{}), k+".")
+				cerr := parse(v.(map[string]interface{}), prefix+k+".")
 				if cerr != nil {
 					if childerrs, ok := cerr.(jsonConfigMapParseErrorList); ok {
 						errs.Merge(childerrs)

--- a/option.go
+++ b/option.go
@@ -36,14 +36,14 @@ type OptionMeta struct {
 	Required bool
 
 	// Filters is a set of boolean functions that are tested with the given value. If Required is true, all of these must succeed.
-	Filters []func(*Option) bool
+	Filters []func(*Option) (bool, error)
 }
 
 // DefaultOptionMeta returns the default OptionMeta object
 var DefaultOptionMeta = OptionMeta{
 	Exportable: false,
 	Required:   false,
-	Filters:    []func(*Option) bool{},
+	Filters:    []func(*Option) (bool, error){},
 }
 
 // String returns the string value of the option. Will panic if the Option's type is not a string.

--- a/option.go
+++ b/option.go
@@ -6,19 +6,6 @@ import (
 	"strconv"
 )
 
-// OptionMask is a type for setting ConfigOptions on Options
-type OptionMask int
-
-const (
-	_ OptionMask = iota
-
-	// Exportable means the Option will be exported to a config.json file
-	Exportable
-
-	// Required means the Option is required and all of the Filters will be tested
-	Required
-)
-
 // Option holds information for a configuration option
 type Option struct {
 	// The name of the option is what's used to reference the option and its value during the program
@@ -49,7 +36,16 @@ type OptionMeta struct {
 	Required bool
 
 	// Filters is a set of boolean functions that are tested with the given value. If Required is true, all of these must succeed.
-	Filters []func(option *Option) bool
+	Filters []FilterFunction
+}
+
+type FilterFunction func(*Option) bool
+
+// DefaultOptionMeta returns the default OptionMeta object
+var DefaultOptionMeta = OptionMeta{
+	Exportable: false,
+	Required:   false,
+	Filters:    []FilterFunction{},
 }
 
 // String returns the string value of the option. Will panic if the Option's type is not a string.
@@ -127,23 +123,3 @@ type sortedOptionSlice []Option
 func (s sortedOptionSlice) Less(a, b int) bool { return s[a].Name < s[b].Name }
 func (s sortedOptionSlice) Swap(a, b int)      { s[a], s[b] = s[b], s[a] }
 func (s sortedOptionSlice) Len() int           { return len(s) }
-
-// DefaultOptionMeta returns the default OptionMeta object
-func DefaultOptionMeta() OptionMeta {
-	s := OptionMeta{
-		Exportable: false,
-		Required:   false,
-		Filters:    []func(*Option) bool{},
-	}
-	return s
-}
-
-func getOptionMetaFromMask(optMask OptionMask) OptionMeta {
-	s := DefaultOptionMeta()
-	s.Exportable = optMask%2 == 1
-	s.Required = (optMask>>1)%2 == 1
-
-	// fmt.Printf("exportable %t required %t\n", s.Exportable, s.Required)
-
-	return s
-}

--- a/option.go
+++ b/option.go
@@ -36,16 +36,14 @@ type OptionMeta struct {
 	Required bool
 
 	// Filters is a set of boolean functions that are tested with the given value. If Required is true, all of these must succeed.
-	Filters []FilterFunction
+	Filters []func(*Option) bool
 }
-
-type FilterFunction func(*Option) bool
 
 // DefaultOptionMeta returns the default OptionMeta object
 var DefaultOptionMeta = OptionMeta{
 	Exportable: false,
 	Required:   false,
-	Filters:    []FilterFunction{},
+	Filters:    []func(*Option) bool{},
 }
 
 // String returns the string value of the option. Will panic if the Option's type is not a string.

--- a/option.go
+++ b/option.go
@@ -32,18 +32,107 @@ type OptionMeta struct {
 	// Exportable is true if the option is exportable to a config.json file
 	Exportable bool
 
-	// Required is true if the option is required
-	Required bool
+	// Validate is true if the option is required
+	Validate bool
 
-	// Filters is a set of boolean functions that are tested with the given value. If Required is true, all of these must succeed.
-	Filters []func(*Option) (bool, error)
+	// Filters is a set of boolean functions that are tested with the given value. If Validate is true, all of these must succeed.
+	Filters []OptionFilterFunc
 }
+
+type OptionFilterFunc func(*Option) (bool, error)
 
 // DefaultOptionMeta returns the default OptionMeta object
 var DefaultOptionMeta = OptionMeta{
 	Exportable: false,
-	Required:   false,
-	Filters:    []func(*Option) (bool, error){},
+	Validate:   true,
+	Filters:    []OptionFilterFunc{},
+}
+
+// String creates an Option with the parameters given of type string
+func String(name string, defaultValue string, description string) *Option {
+
+	v := Option{
+		Name:        name,
+		Description: description,
+
+		DefaultValue: reflect.ValueOf(defaultValue),
+		Value:        defaultValue,
+		Type:         reflect.TypeOf(defaultValue),
+
+		Options: DefaultOptionMeta,
+	}
+
+	return &v
+}
+
+// Bool creates an Option with the parameters given of type bool
+func Bool(name string, defaultValue bool, description string) *Option {
+	v := Option{
+		Name:        name,
+		Description: description,
+
+		DefaultValue: reflect.ValueOf(defaultValue),
+		Value:        defaultValue,
+		Type:         reflect.TypeOf(defaultValue),
+
+		Options: DefaultOptionMeta,
+	}
+
+	return &v
+}
+
+// Int creates an Option with the parameters given of type int64
+func Int(name string, defaultValue int64, description string) *Option {
+	v := Option{
+		Name:        name,
+		Description: description,
+
+		DefaultValue: reflect.ValueOf(defaultValue),
+		Value:        defaultValue,
+		Type:         reflect.TypeOf(defaultValue),
+
+		Options: DefaultOptionMeta,
+	}
+
+	return &v
+}
+
+// Float creates an Option with the parameters given of type float64
+func Float(name string, defaultValue float64, description string) *Option {
+	v := Option{
+		Name:        name,
+		Description: description,
+
+		DefaultValue: reflect.ValueOf(defaultValue),
+		Value:        defaultValue,
+		Type:         reflect.TypeOf(defaultValue),
+
+		Options: DefaultOptionMeta,
+	}
+
+	return &v
+}
+
+// Enum creates an Option with the parameters given of type string and a built-in validation to make sure
+// that the parsed Option value is contained within the possibleValues argument.
+func Enum(name string, possibleValues []string, defaultValue string, description string) *Option {
+
+	v := Option{
+		Name:        name,
+		Description: description,
+
+		DefaultValue: reflect.ValueOf(defaultValue),
+		Value:        defaultValue,
+		Type:         reflect.TypeOf(defaultValue),
+
+		Options: DefaultOptionMeta,
+	}
+
+	v.
+		Validate(true).
+		AddFilter(IsOneOfStrings(possibleValues))
+
+	return &v
 }
 
 // String returns the string value of the option. Will panic if the Option's type is not a string.
@@ -114,6 +203,22 @@ func (o *Option) SetFromString(val string) (err error) {
 	}
 
 	return
+}
+
+func (o *Option) Exportable(v bool) *Option {
+	o.Options.Exportable = v
+	return o
+}
+
+func (o *Option) Validate(v bool) *Option {
+	o.Options.Validate = v
+	return o
+}
+
+func (o *Option) AddFilter(v OptionFilterFunc) *Option {
+	o.Options.Filters = append(o.Options.Filters, v)
+	o.Options.Validate = true
+	return o
 }
 
 type sortedOptionSlice []Option

--- a/option_set.go
+++ b/option_set.go
@@ -58,6 +58,7 @@ func (os OptionSet) Require(key string) *Option {
 	return result
 }
 
+// Validate checks all Options in an OptionSet and returns an error if any of them don't pass any of their Filters and are Required.
 func (os OptionSet) Validate() error {
 	hasError := false
 	invalidOpts := []string{}
@@ -70,7 +71,7 @@ func (os OptionSet) Validate() error {
 			if !validOption {
 				invalidOpts = append(invalidOpts, v.Name)
 			}
-			hasError = hasError && validOption
+			hasError = hasError || !validOption
 		}
 	}
 

--- a/option_set.go
+++ b/option_set.go
@@ -63,16 +63,14 @@ func (os OptionSet) Validate() error {
 	hasError := false
 	invalidOpts := []string{}
 	for _, v := range os {
-		if v.Options.Required {
-			validOption := true
-			for _, f := range v.Options.Filters {
-				validOption = validOption && f(v)
-			}
-			if !validOption {
-				invalidOpts = append(invalidOpts, v.Name)
-			}
-			hasError = hasError || !validOption
+		validOption := true
+		for _, f := range v.Options.Filters {
+			validOption = validOption && f(v)
 		}
+		if !validOption {
+			invalidOpts = append(invalidOpts, v.Name)
+		}
+		hasError = hasError || !validOption
 	}
 
 	if hasError {


### PR DESCRIPTION
Adding a more robust API for setting options on config options. Starting with `Exportable` (existing functionality) and `Required`.

Fixes #6.